### PR TITLE
Add zsh-based tests for akskrotate script

### DIFF
--- a/tests/run_tests.zsh
+++ b/tests/run_tests.zsh
@@ -1,0 +1,12 @@
+#!/usr/bin/env zsh
+set -e
+for t in $(dirname $0)/test_*.zsh; do
+  echo "Running ${t}..."
+  if /usr/bin/zsh "$t"; then
+    echo "OK: ${t}"
+  else
+    echo "FAILED: ${t}"
+    exit 1
+  fi
+done
+echo "All tests passed"

--- a/tests/test_missing_awscli.zsh
+++ b/tests/test_missing_awscli.zsh
@@ -1,0 +1,19 @@
+#!/usr/bin/env zsh
+SCRIPT_DIR=$(cd $(dirname $0)/.. && pwd)
+AKSKROTATE="$SCRIPT_DIR/distribution/bin/akskrotate"
+set +e
+export AWS_PROFILE=dummy
+tmp=$(mktemp -d)
+ln -s $(which jq) $tmp/jq
+PATH=$tmp
+output=$(/usr/bin/zsh "$AKSKROTATE" 2>&1)
+rc=$?
+/bin/rm -rf $tmp
+set -e
+if [[ $rc -eq 1 && "$output" == "Please install the AWS CLI before calling akskrotate" ]]; then
+  exit 0
+else
+  echo "expected exit code 1 and message 'Please install the AWS CLI before calling akskrotate'"
+  echo "got exit code $rc, output: $output"
+  exit 1
+fi

--- a/tests/test_missing_jq.zsh
+++ b/tests/test_missing_jq.zsh
@@ -1,0 +1,16 @@
+#!/usr/bin/env zsh
+SCRIPT_DIR=$(cd $(dirname $0)/.. && pwd)
+AKSKROTATE="$SCRIPT_DIR/distribution/bin/akskrotate"
+set +e
+export AWS_PROFILE=dummy
+PATH=/nonexistent
+output=$(/usr/bin/zsh "$AKSKROTATE" 2>&1)
+rc=$?
+set -e
+if [[ $rc -eq 1 && "$output" == "Please install jq before calling akskrotate" ]]; then
+  exit 0
+else
+  echo "expected exit code 1 and message 'Please install jq before calling akskrotate'"
+  echo "got exit code $rc, output: $output"
+  exit 1
+fi

--- a/tests/test_missing_profile.zsh
+++ b/tests/test_missing_profile.zsh
@@ -1,0 +1,15 @@
+#!/usr/bin/env zsh
+SCRIPT_DIR=$(cd $(dirname $0)/.. && pwd)
+AKSKROTATE="$SCRIPT_DIR/distribution/bin/akskrotate"
+set +e
+unset AWS_PROFILE
+output=$(/usr/bin/zsh "$AKSKROTATE" 2>&1)
+rc=$?
+set -e
+if [[ $rc -eq 1 && "$output" == "Please set AWS_PROFILE before calling akskrotate" ]]; then
+  exit 0
+else
+  echo "expected exit code 1 and message 'Please set AWS_PROFILE before calling akskrotate'"
+  echo "got exit code $rc, output: $output"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add a simple zsh test suite in a new `tests` directory
- verify behaviour when `AWS_PROFILE` is missing
- verify error messages for missing `jq` and AWS CLI

## Testing
- `tests/run_tests.zsh`