### PR TITLE
Fix cp quoting in akskrotate

### DIFF
--- a/distribution/bin/akskrotate
+++ b/distribution/bin/akskrotate
@@ -136,7 +136,7 @@ fi
 # backup credentials file just in case
 
 echo "Backing up your credentials file into ${AWS_SHARED_CREDENTIALS_FILE:-~/.aws/credentials}.akskrotate .."
-cp ${AWS_SHARED_CREDENTIALS_FILE:-~/.aws/credentials} ${AWS_SHARED_CREDENTIALS_FILE:-~/.aws/credentials}.akskrotate
+cp "${AWS_SHARED_CREDENTIALS_FILE:-~/.aws/credentials}" "${AWS_SHARED_CREDENTIALS_FILE:-~/.aws/credentials}.akskrotate"
 
 # store credentials in ~/.aws/credentials
 


### PR DESCRIPTION
## Summary
- quote path variables in cp command so paths with spaces work

## Testing
- `cp "${AWS_SHARED_CREDENTIALS_FILE:-~/.aws/credentials}" "${AWS_SHARED_CREDENTIALS_FILE:-~/.aws/credentials}.akskrotate"` with a credentials path containing spaces